### PR TITLE
Web server showing Product list

### DIFF
--- a/web-server_deployment.yml
+++ b/web-server_deployment.yml
@@ -18,7 +18,6 @@ spec:
       containers:
       - name: web-server
         image: quay.io/didierofrivia/go-fetch-products:latest
-        imagePullPolicy: IfNotPresent
         env:
         - name: PORT
           value: "8080"

--- a/web-server_deployment.yml
+++ b/web-server_deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-server-deployment
+  namespace: k8sinitiative
+spec:
+  selector:
+    matchLabels:
+      app: web-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: web-server
+    spec:
+      serviceAccountName: products-admin
+      namespace: k8sinitiative
+      containers:
+      - name: web-server
+        image: quay.io/didierofrivia/go-fetch-products:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "8080"
+        ports:
+        - containerPort: 8080

--- a/web-server_service.yml
+++ b/web-server_service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-server
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: web-server


### PR DESCRIPTION
Closes https://github.com/3scale/k8sapp-initiative/issues/9
Closes https://github.com/3scale/k8sapp-initiative/issues/13

The web server used in this template can be found [here](https://github.com/didierofrivia/go-fetch-products)

This is how it looks when you visit http://k8sinitiative.apps.dev-eng-ocp4-5.dev.3sca.net/products

<img width="664" alt="Screenshot 2020-11-27 at 16 05 55" src="https://user-images.githubusercontent.com/4183971/100431405-b39efc00-30ca-11eb-9373-4363229d797a.png">

Notes:

1. I've coded the web server in a different repo because it was messing with the controller code previously written. Afterwards we could decide how to structure the code and include it in this repo -> https://github.com/3scale/k8sapp-initiative/pull/19
2. I've created an Openshift Route directly with the UI. We need to decide whether we want to go this way and include the yaml file, or go k8s way and craft the ingress object.