### PR TITLE
Use configMap to set env vars

### DIFF
--- a/configmap.yml
+++ b/configmap.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-initiative-configmap
+data:
+  namespace: "k8sinitiative"
+  web_server_port: "8080"

--- a/controller/main.go
+++ b/controller/main.go
@@ -17,7 +17,10 @@ var kubeconfig string
 
 func main() {
 
-	ns := "k8sinitiative"
+	ns, ok := os.LookupEnv("NAMESPACE")
+	if !ok {
+		ns = "default"
+	}
 
 	s := scheme.Scheme
 	v1alpha1.AddToScheme(s)

--- a/web-server/pkg/main.go
+++ b/web-server/pkg/main.go
@@ -52,8 +52,8 @@ func StartWebServer() {
 	http.HandleFunc(productsEndPoint, handleProductsPage)
 	fs := http.FileServer(http.Dir("./templates/styles"))
 	http.Handle("/templates/styles/", http.StripPrefix("/templates/styles/", fs))
-	port := os.Getenv("PORT")
-	if len(port) == 0 {
+	port, ok := os.LookupEnv("PORT")
+	if !ok {
 		panic("Environment variable PORT is not set")
 	}
 
@@ -82,10 +82,14 @@ func handleHomePage(w http.ResponseWriter, r *http.Request) {
 
 func handleProductsPage(w http.ResponseWriter, r *http.Request) {
 	result := v1alpha1.ProductList{}
+	ns, ok := os.LookupEnv("NAMESPACE")
+	if !ok {
+		ns = "default"
+	}
 
 	getErr := restClient.
 		Get().
-		Namespace("k8sinitiative").
+		Namespace(ns).
 		Resource("products").
 		Do().
 		Into(&result)

--- a/web-server_deployment.yml
+++ b/web-server_deployment.yml
@@ -16,10 +16,26 @@ spec:
       serviceAccountName: products-admin
       namespace: k8sinitiative
       containers:
-      - name: web-server
-        image: quay.io/didierofrivia/go-fetch-products:latest
-        env:
-        - name: PORT
-          value: "8080"
-        ports:
-        - containerPort: 8080
+        - name: web-server
+          image: quay.io/didierofrivia/go-fetch-products:latest
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: k8s-initiative-configmap
+                  key: namespace
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  -name: k8s-initiative-configmap
+                  key: web_server_port
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: config-volume
+              mountPath: "/config"
+              readOnly: true
+          volumes:
+            - name: config-volume
+              configMap:
+                name: k8s-initiative-configmap


### PR DESCRIPTION
First step to make our application more portable, using a configMap to set the env vars required in the web server.

**Verification steps:**

Create configMap in cluster
```
oc apply -f configmap.yml
```

Build and push container image:
```
DOCKER_BUILDKIT=1 docker build -f Dockerfile -t <YOUR_IMAGE_TAG> .
docker push <YOUR_IMAGE_TAG> 
```